### PR TITLE
Add missing scripts for dev and database setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "dev": "npm start",
+    "db:migrate": "echo \"No migrations script found\"",
+    "db:seed": "echo \"No seed script found\"",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
## Summary
- add npm scripts for development and stub database tasks

## Testing
- `npm install`
- `npm run db:migrate`
- `npm run db:seed`
- `npm run dev`
- `npm test -- --watchAll=false` *(fails: Test Suites: 3 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b87b7e5edc83318353106e57d6f31a